### PR TITLE
Implement and document deprecated-stateless-component

### DIFF
--- a/.changeset/hip-frogs-exist.md
+++ b/.changeset/hip-frogs-exist.md
@@ -1,0 +1,5 @@
+---
+"types-react-codemod": minor
+---
+
+Implement `deprecated-stateless-component` transform.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # types-react-codemod
 
-Collection of transforms for jscodeshift related to `@types/react`.
+Collection of transforms for [jscodeshift](https://github.com/facebook/jscodeshift) related to `@types/react`.
 
 ## Usage
 
@@ -28,7 +28,20 @@ Options:
 - `deprecated-react-type`
 - `deprecated-sfc-element`
 - `deprecated-sfc`
+- `deprecated-stateless-component`
 - `useCallback-implicit-any`
 - `context-any` (not implemented)
-- `deprecated-stateless-component`
 - `implicit-children` (not implemented)
+
+## False-Positives
+
+Some transforms change code they shouldn't actually change.
+Fixing all of these requires a lot of implementation effort.
+When considering false-positives vs false-negatives, I opt for false-positives.
+The reason being that a false-positive can be reverted easily (assuming you use have the changed code in Version Control e.g. git) while a false-negative requires manual input.
+
+### All `deprecated-` transforms
+
+They simply rename identifiers with a specific name.
+If you have a type with the same name from a different package, then the rename results in a false positive.
+For example, `ink` also has a `StatelessComponent` but you don't need to rename that type since it's not deprecated.

--- a/transforms/deprecated-stateless-component.js
+++ b/transforms/deprecated-stateless-component.js
@@ -1,18 +1,20 @@
 const parseSync = require("./utils/parseSync");
 
-/* eslint-disable no-unreachable */
-throw new Error("not implemented");
-
 /**
  * @type {import('jscodeshift').Transform}
- * test:
+ * test: https://astexplorer.net/#/gist/ebd4c5257e3b5385a860de26edab25a0/a9df97df215041311c96c309683bdb9cad5b7b01
  */
 const transformer = (file, api) => {
-	// eslint-disable-next-line no-unused-vars
 	const j = api.jscodeshift;
 	const ast = parseSync(file);
 
-	const changedIdentifiers = [];
+	const changedIdentifiers = ast
+		.find(j.Identifier, (node) => {
+			return node.name === "StatelessComponent";
+		})
+		.replaceWith(() => {
+			return j.identifier("FunctionComponent");
+		});
 
 	// Otherwise some files will be marked as "modified" because formatting changed
 	if (changedIdentifiers.length > 0) {


### PR DESCRIPTION
adds documentation for false-positives in other `deprecate-*` transforms as well.