### PR TITLE
Only run codemod on tsx? files

### DIFF
--- a/bin/types-react-codemod.cjs
+++ b/bin/types-react-codemod.cjs
@@ -51,7 +51,7 @@ async function main() {
 				 * @type {string[]}
 				 */
 				const args = [
-					"--extensions=tsx,ts,jsx,js,cjs,mjs",
+					"--extensions=tsx,ts",
 					"--ignore-pattern=**/node_modules/**",
 					`--transform ${path.join(transformsRoot, `${codemod}.js`)}`,
 				];

--- a/transforms/useCallback-implicit-any.js
+++ b/transforms/useCallback-implicit-any.js
@@ -14,12 +14,6 @@ const parseSync = require("./utils/parseSync");
  * BUT this gets increasingly complicated if this becomes `const foo = () => useCallback(event => {})`
  */
 const useCallbackImplicitAnyTransform = (file, api) => {
-	const fileSupportsTypeAnnotations =
-		file.path.endsWith(".ts") || file.path.endsWith(".tsx");
-	if (!fileSupportsTypeAnnotations) {
-		return;
-	}
-
 	const j = api.jscodeshift;
 	const ast = parseSync(file);
 


### PR DESCRIPTION
Since all these changes are related to types, we don't need to run on untyped files.

We already had to special-case untyped files in `useCallback-implicit-any`. We would've needed the same special-case for `context-any`.

Let's just apply this special case consistently.