### PR TITLE
Only check Yarn cache on PRs from forks

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -24,7 +24,7 @@ jobs:
       - run: yarn install --immutable --immutable-cache
       - name: Check Yarn cache
         # Only run on forks
-        if: ${{ !secrets.NPM_AUTOMATION_TOKEN }}
+        if: ${{ !(secrets.NPM_AUTOMATION_TOKEN) }}
         run: yarn --check-cache
       - run: yarn test:unit
       - run: yarn test:lint

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -24,7 +24,7 @@ jobs:
       - run: yarn install --immutable --immutable-cache
       - name: Check Yarn cache
         # Only run on forks
-        if: ${{ secrets.NPM_AUTOMATION_TOKE != '' }}
+        if: github.repository_owner != 'eps1lon'
         run: yarn --check-cache
       - run: yarn test:unit
       - run: yarn test:lint

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -24,7 +24,7 @@ jobs:
       - run: yarn install --immutable --immutable-cache
       - name: Check Yarn cache
         # Only run on forks
-        if: !(secrets.NPM_AUTOMATION_TOKEN)
+        if: secrets.NPM_AUTOMATION_TOKE != ''
         run: yarn --check-cache
       - run: yarn test:unit
       - run: yarn test:lint

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -24,7 +24,7 @@ jobs:
       - run: yarn install --immutable --immutable-cache
       - name: Check Yarn cache
         # Only run on forks
-        if: secrets.NPM_AUTOMATION_TOKE != ''
+        if: ${{ secrets.NPM_AUTOMATION_TOKE != '' }}
         run: yarn --check-cache
       - run: yarn test:unit
       - run: yarn test:lint

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -21,7 +21,11 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
-      - run: yarn install --immutable --immutable-cache --check-cache
+      - run: yarn install --immutable --immutable-cache
+      - name: Check Yarn cache
+      # Only run on forks
+        if: ${{ !secrets.NPM_AUTOMATION_TOKEN }}
+        run: yarn --check-cache
       - run: yarn test:unit
       - run: yarn test:lint
       - run: yarn test:types

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -24,7 +24,7 @@ jobs:
       - run: yarn install --immutable --immutable-cache
       - name: Check Yarn cache
         # Only run on forks
-        if: ${{ !(secrets.NPM_AUTOMATION_TOKEN) }}
+        if: !(secrets.NPM_AUTOMATION_TOKEN)
         run: yarn --check-cache
       - run: yarn test:unit
       - run: yarn test:lint

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -23,7 +23,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - run: yarn install --immutable --immutable-cache
       - name: Check Yarn cache
-      # Only run on forks
+        # Only run on forks
         if: ${{ !secrets.NPM_AUTOMATION_TOKEN }}
         run: yarn --check-cache
       - run: yarn test:unit


### PR DESCRIPTION
Checking cache takes up to 2mins currently making up 90% of CI time.

Implies that we trust PRs from people with write access