### PR TITLE
fix: Parse .ts files without JSX plugin

### DIFF
--- a/.changeset/tough-dolphins-teach.md
+++ b/.changeset/tough-dolphins-teach.md
@@ -1,0 +1,15 @@
+---
+"types-react-codemod": patch
+---
+
+Parse .ts files without JSX plugin.
+
+Otherwise code such as
+
+```ts
+(<RegExp>expected).test(object);
+```
+
+-- https://github.com/DefinitelyTyped/DefinitelyTyped/blob/3eacc5e0b7c56d2670a5a0e68735f7638e8f38f3/types/chai-like/chai-like-tests.ts#L15
+
+could not be parsed.

--- a/transforms/utils/__tests__/parseSync.js
+++ b/transforms/utils/__tests__/parseSync.js
@@ -1,0 +1,14 @@
+import { describe, expect, test } from "@jest/globals";
+import parseSync from "../parseSync";
+
+describe("parseSync", () => {
+	test("oldschool type casts in ts files", () => {
+		expect(() =>
+			parseSync({
+				// based on https://github.com/DefinitelyTyped/DefinitelyTyped/blob/3eacc5e0b7c56d2670a5a0e68735f7638e8f38f3/types/chai-like/chai-like-tests.ts
+				path: "test.ts",
+				source: `(<RegExp> expected).test(object);`,
+			})
+		).not.toThrow();
+	});
+});

--- a/transforms/utils/parseSync.js
+++ b/transforms/utils/parseSync.js
@@ -26,7 +26,6 @@ const baseParserOptions = {
 		"functionBind",
 		"functionSent",
 		"importMeta",
-		"jsx",
 		"nullishCoalescingOperator",
 		"numericSeparator",
 		"objectRestSpread",
@@ -41,9 +40,13 @@ const dtsParserOptions = {
 	...baseParserOptions,
 	plugins: [...baseParserOptions.plugins, ["typescript", { dts: true }]],
 };
-const parserOptions = {
+const tsParserOptions = {
 	...baseParserOptions,
 	plugins: [...baseParserOptions.plugins, ["typescript", { dts: false }]],
+};
+const tsxParserOptions = {
+	...tsParserOptions,
+	plugins: [...tsParserOptions.plugins, "jsx"],
 };
 
 /**
@@ -52,6 +55,7 @@ const parserOptions = {
  */
 function parseSync(fileInfo) {
 	const dts = fileInfo.path.endsWith(".d.ts");
+	const tsx = fileInfo.path.endsWith(".tsx");
 
 	return j(fileInfo.source, {
 		parser: {
@@ -69,7 +73,11 @@ function parseSync(fileInfo) {
 						// So if the parser fails in an ambient context we just try again without ambient context
 					}
 				}
-				return babylon.parse(code, parserOptions);
+				if (tsx) {
+					return babylon.parse(code, tsxParserOptions);
+				} else {
+					return babylon.parse(code, tsParserOptions);
+				}
 			},
 		},
 	});


### PR DESCRIPTION
Closes https://github.com/eps1lon/types-react-codemod/issues/45