### PR TITLE
Test with Node.js 18

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 17.x]
+        node-version: [14.x, 16.x, 17.x, 18.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:


### PR DESCRIPTION
Seems like 18 is supported by Jest 28. [Prior failures](https://github.com/eps1lon/types-react-codemod/runs/6152638389?check_suite_focus=true) (https://github.com/eps1lon/types-react-codemod/pull/27) happened with jest 27