### PR TITLE
feat: Avoid transpiling transforms

### DIFF
--- a/.changeset/smart-lamps-type.md
+++ b/.changeset/smart-lamps-type.md
@@ -1,0 +1,8 @@
+---
+"types-react-codemod": minor
+---
+
+Avoid transpiling transforms
+
+Previously jscodeshift would transpile the transforms before using them.
+This was largely unnecessary and resulted in bugs to to usage of undeclared Babel dependencies.

--- a/bin/types-react-codemod.cjs
+++ b/bin/types-react-codemod.cjs
@@ -64,6 +64,8 @@ async function main() {
 				const args = [
 					"--extensions=tsx,ts",
 					`"--ignore-pattern=${argv.ignorePattern}"`,
+					// The transforms are published as JS compatible with the supported Node.js versions.
+					"--no-babel",
 					`--transform ${path.join(transformsRoot, `${codemod}.js`)}`,
 				];
 

--- a/transforms/context-any.js
+++ b/transforms/context-any.js
@@ -108,4 +108,4 @@ const contextAnyTransform = (file, api) => {
 	return file.source;
 };
 
-export default contextAnyTransform;
+module.exports = contextAnyTransform;

--- a/transforms/deprecated-react-child.js
+++ b/transforms/deprecated-react-child.js
@@ -44,4 +44,4 @@ const deprecatedReactChildTransform = (file, api) => {
 	return file.source;
 };
 
-export default deprecatedReactChildTransform;
+module.exports = deprecatedReactChildTransform;

--- a/transforms/deprecated-react-text.js
+++ b/transforms/deprecated-react-text.js
@@ -37,4 +37,4 @@ const deprecatedReactTextTransform = (file, api) => {
 	return file.source;
 };
 
-export default deprecatedReactTextTransform;
+module.exports = deprecatedReactTextTransform;

--- a/transforms/deprecated-react-type.js
+++ b/transforms/deprecated-react-type.js
@@ -22,4 +22,4 @@ const deprecatedReactTypeTransform = (file, api) => {
 	return file.source;
 };
 
-export default deprecatedReactTypeTransform;
+module.exports = deprecatedReactTypeTransform;

--- a/transforms/deprecated-sfc-element.js
+++ b/transforms/deprecated-sfc-element.js
@@ -22,4 +22,4 @@ const deprecatedSFCElementTransform = (file, api) => {
 	return file.source;
 };
 
-export default deprecatedSFCElementTransform;
+module.exports = deprecatedSFCElementTransform;

--- a/transforms/deprecated-sfc.js
+++ b/transforms/deprecated-sfc.js
@@ -22,4 +22,4 @@ const deprecatedSFCTransform = (file, api) => {
 	return file.source;
 };
 
-export default deprecatedSFCTransform;
+module.exports = deprecatedSFCTransform;

--- a/transforms/deprecated-stateless-component.js
+++ b/transforms/deprecated-stateless-component.js
@@ -22,4 +22,4 @@ const deprecatedStatelessComponentTransform = (file, api) => {
 	return file.source;
 };
 
-export default deprecatedStatelessComponentTransform;
+module.exports = deprecatedStatelessComponentTransform;

--- a/transforms/deprecated-void-function-component.js
+++ b/transforms/deprecated-void-function-component.js
@@ -24,4 +24,4 @@ const deprecatedVoidFunctionComponentTransform = (file, api) => {
 	return file.source;
 };
 
-export default deprecatedVoidFunctionComponentTransform;
+module.exports = deprecatedVoidFunctionComponentTransform;

--- a/transforms/implicit-children.js
+++ b/transforms/implicit-children.js
@@ -71,4 +71,4 @@ const implicitChildrenTransform = (file, api) => {
 	return file.source;
 };
 
-export default implicitChildrenTransform;
+module.exports = implicitChildrenTransform;

--- a/transforms/preset-18.js
+++ b/transforms/preset-18.js
@@ -71,4 +71,4 @@ const transform = (file, api, options) => {
 	}
 };
 
-export default transform;
+module.exports = transform;

--- a/transforms/preset-19.js
+++ b/transforms/preset-19.js
@@ -47,4 +47,4 @@ const transform = (file, api, options) => {
 	}
 };
 
-export default transform;
+module.exports = transform;

--- a/transforms/useCallback-implicit-any.js
+++ b/transforms/useCallback-implicit-any.js
@@ -99,4 +99,4 @@ const useCallbackImplicitAnyTransform = (file, api) => {
 	return file.source;
 };
 
-export default useCallbackImplicitAnyTransform;
+module.exports = useCallbackImplicitAnyTransform;


### PR DESCRIPTION
Closes https://github.com/eps1lon/types-react-codemod/issues/62

Previously jscodeshift would transpile the transforms before using them.
This was largely unnecessary and resulted in bugs to to usage of undeclared Babel dependencies.

Tested it by running the bin without the `module.exports` and it failed as expected since it needs the files as CommonJS. Previously jscodeshift transpiled the transforms so we didn't catch this problem.