### PR TITLE
feat: Ensure TypeScript instantiation expressions can be parsed

### DIFF
--- a/.changeset/heavy-rockets-guess.md
+++ b/.changeset/heavy-rockets-guess.md
@@ -1,0 +1,7 @@
+---
+"types-react-codemod": minor
+---
+
+Ensure TypeScript instantiation expressions can be parsed
+
+[Instantiation expressions](https://devblogs.microsoft.com/typescript/announcing-typescript-4-7/#instantiation-expressions) were added in TypeScript 4.7.

--- a/transforms/utils/__tests__/parseSync.js
+++ b/transforms/utils/__tests__/parseSync.js
@@ -11,4 +11,13 @@ describe("parseSync", () => {
 			})
 		).not.toThrow();
 	});
+
+	test("TSInstantiationExpression", () => {
+		expect(() =>
+			parseSync({
+				path: "test.ts",
+				source: `const makeStringBox = makeBox<string>;`,
+			})
+		).not.toThrow();
+	});
 });


### PR DESCRIPTION
Closes #91

They were probably pulling in an older version of Babel. This PR just adds a test for behavior fixed in Babel 7.18 (bumped in https://github.com/eps1lon/types-react-codemod/pull/67). This way we get a release with the (already) bumped version of Babel 