### PR TITLE
feat: Make supported Node.js version explicit

### DIFF
--- a/.changeset/selfish-candles-hide.md
+++ b/.changeset/selfish-candles-hide.md
@@ -1,0 +1,10 @@
+---
+"types-react-codemod": major
+---
+
+Fail install if used version of Node.js is not officially supported
+
+Add a list of supported versions of Node.js to `engines` in `package.json`.
+If the current version does not match, installation will fail (by default in Yarn and in NPM only if the [`engine-strict` config is enabled](https://docs.npmjs.com/cli/v8/using-npm/config#engine-strict)).
+
+This warning can be ignored either by setting `engine-strict` to `false` in NPM (default) or add `--ignore-engines` to `yarn` (e.g. `yarn --ignore-engines`).

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -12,7 +12,8 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 17.x, 18.x]
+        # #nodejs-suppport
+        node-version: [14.x, 16.x, 17.x, 18.x, 19.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:

--- a/README.md
+++ b/README.md
@@ -261,3 +261,12 @@ In earlier versions of `@types/react` this codemod would change the typings.
 -const Component: React.VoidFunctionComponent = () => {}
 +const Component: React.FunctionComponent = () => {}
 ```
+
+## Supported platforms
+
+The following list contains officially supported runtimes.
+Please file an issue for runtimes that are not included in this list.
+
+<!-- #nodejs-suppport Should match CI test matrix -->
+
+- Node.js `14.x || 16.x || 17.x || 18.x || 19.x`

--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
 		"test:types": "tsc -p tsconfig.json --noEmit",
 		"test:unit": "jest"
 	},
+	"engines": {
+		"node": "14.x || 16.x || 17.x || 18.x || 19.x"
+	},
 	"dependencies": {
 		"@babel/core": "^7.17.8",
 		"@babel/preset-env": "^7.16.11",


### PR DESCRIPTION
Node 14 was required implicitly but with https://github.com/eps1lon/types-react-codemod/pull/84 we'll definitely fail module evaluation (due to usage of `import()`) when used with Node.js 12 and no experimental modules flag.