### PR TITLE
use-global-types

### DIFF
--- a/bin/__tests__/types-react-codemod.js
+++ b/bin/__tests__/types-react-codemod.js
@@ -25,7 +25,7 @@ describe("types-react-codemod", () => {
 		     "deprecated-react-text", "deprecated-react-type", "deprecated-sfc-element",
 		                             "deprecated-sfc", "deprecated-stateless-component",
 		         "deprecated-void-function-component", "implicit-children", "preset-18",
-		                                        "preset-19", "useCallback-implicit-any"]
+		                    "preset-19", "use-global-types", "useCallback-implicit-any"]
 		  paths                                                      [string] [required]
 
 		Options:

--- a/transforms/__tests__/use-global-types.js
+++ b/transforms/__tests__/use-global-types.js
@@ -1,0 +1,105 @@
+const { describe, expect, test } = require("@jest/globals");
+const dedent = require("dedent");
+const JscodeshiftTestUtils = require("jscodeshift/dist/testUtils");
+const useGlobalTypes = require("../use-global-types");
+
+function applyTransform(source, options = {}) {
+	return JscodeshiftTestUtils.applyTransform(useGlobalTypes, options, {
+		path: "test.d.ts",
+		source: dedent(source),
+	});
+}
+
+describe("use global types", () => {
+	test("not modified imports with *", () => {
+		expect(
+			applyTransform(`
+			import * as React from 'react';
+			interface Props {
+				children?: ReactNode;
+			}
+    `)
+		).toMatchInlineSnapshot(`
+		"import * as React from 'react';
+					interface Props {
+						children?: React.ReactNode;
+					}"
+	`);
+	});
+
+	test("single import gets removed", () => {
+		expect(
+			applyTransform(`
+      import { ReactChild } from 'react';
+		interface Props {
+				children?: ReactChild;
+			}
+    `)
+		).toMatchInlineSnapshot(`
+		"interface Props {
+		        children?: React.ReactChild;
+		    }"
+	`);
+	});
+
+	test("two imports gets removed", () => {
+		expect(
+			applyTransform(`
+      import { ReactChild, MouseEvent } from 'react';
+		interface Props {
+				children?: ReactChild;
+				onClick?: MouseEvent;
+			}
+    `)
+		).toMatchInlineSnapshot(`
+		"interface Props {
+		        children?: React.ReactChild;
+		        onClick?: React.MouseEvent;
+		    }"
+	`);
+	});
+
+	test("named import with multiple types", () => {
+		expect(
+			applyTransform(`
+	  import { ReactChild, ReactNode } from 'react';
+		interface Props {
+				children?: ReactChild;
+			}
+	`)
+		).toMatchInlineSnapshot(`
+		"import { ReactNode } from 'react';
+				interface Props {
+						children?: React.ReactChild;
+					}"
+	`);
+	});
+
+	test("mixed imports with unused", () => {
+		expect(
+			applyTransform(`
+	  import { ReactChild, ReactNode, useState, useCallback } from 'react';
+		interface Props {
+				children?: ReactChild;
+			}
+
+			function MyComponent() {
+				const [state, setState] = useState<number>(0);
+				
+				return state
+			}
+	`)
+		).toMatchInlineSnapshot(`
+		"import { ReactNode, useState, useCallback } from 'react';
+				interface Props {
+						children?: React.ReactChild;
+					}
+
+					function MyComponent() {
+						const [state, setState] = useState<number>(0);
+						
+						return state
+					}"
+	`);
+	});
+});

--- a/transforms/use-global-types.js
+++ b/transforms/use-global-types.js
@@ -1,0 +1,187 @@
+const parseSync = require("./utils/parseSync");
+
+// this is a list of all @types/react imports
+const typesToRemove = new Set([
+	"ReactText",
+	"ReactNode",
+	"ReactElement",
+	"ReactFragment",
+	"ReactPortal",
+	"ReactNodeArray",
+	"ReactChild",
+	"ReactChildren",
+	"ReactComponentElement",
+	"Dispatch",
+	"SyntheticEvent",
+	"MouseEvent",
+	"MouseEventHandler",
+	"KeyboardEvent",
+	"KeyboardEventHandler",
+	"FocusEvent",
+	"FocusEventHandler",
+	"ChangeEvent",
+	"ChangeEventHandler",
+	"DragEvent",
+	"DragEventHandler",
+	"TouchEvent",
+	"TouchEventHandler",
+	"AnimationEvent",
+	"AnimationEventHandler",
+	"PropsWithRef",
+	"PropsWithoutRef",
+	"PropsWithChildren",
+	"ElementType",
+	"ComponentType",
+	"Ref",
+	"RefCallback",
+	"LegacyRef",
+	"ComponentProps",
+	"ComponentPropsWithRef",
+	"ComponentPropsWithoutRef",
+	"Attributes",
+	"ClassAttributes",
+	"RefAttributes",
+	"HTMLProps",
+	"DetailedHTMLProps",
+	"HTMLAttributes",
+	"AnchorHTMLAttributes",
+	"AreaHTMLAttributes",
+	"AudioHTMLAttributes",
+	"BaseHTMLAttributes",
+	"BlockquoteHTMLAttributes",
+	"ButtonHTMLAttributes",
+	"CanvasHTMLAttributes",
+	"ColHTMLAttributes",
+	"ColgroupHTMLAttributes",
+	"DataHTMLAttributes",
+	"DetailsHTMLAttributes",
+	"DialogHTMLAttributes",
+	"EmbedHTMLAttributes",
+	"FieldsetHTMLAttributes",
+	"FormHTMLAttributes",
+	"HtmlHTMLAttributes",
+	"IframeHTMLAttributes",
+	"ImgHTMLAttributes",
+	"InputHTMLAttributes",
+	"InsHTMLAttributes",
+	"KeygenHTMLAttributes",
+	"LabelHTMLAttributes",
+	"LegendHTMLAttributes",
+	"LiHTMLAttributes",
+	"LinkHTMLAttributes",
+	"MainHTMLAttributes",
+	"MapHTMLAttributes",
+	"MenuHTMLAttributes",
+	"MenuitemHTMLAttributes",
+	"MetaHTMLAttributes",
+	"MeterHTMLAttributes",
+	"ObjectHTMLAttributes",
+	"OlHTMLAttributes",
+	"OptgroupHTMLAttributes",
+	"OptionHTMLAttributes",
+	"OutputHTMLAttributes",
+	"ParamHTMLAttributes",
+	"ProgressHTMLAttributes",
+	"QuoteHTMLAttributes",
+	"ScriptHTMLAttributes",
+	"SelectHTMLAttributes",
+	"SourceHTMLAttributes",
+	"StyleHTMLAttributes",
+	"TableHTMLAttributes",
+	"TdHTMLAttributes",
+	"TextareaHTMLAttributes",
+	"TfootHTMLAttributes",
+	"ThHTMLAttributes",
+	"TheadHTMLAttributes",
+	"TimeHTMLAttributes",
+	"TitleHTMLAttributes",
+	"TrackHTMLAttributes",
+	"UHTMLAttributes",
+	"UlHTMLAttributes",
+	"VarHTMLAttributes",
+	"VideoHTMLAttributes",
+	"SVGProps",
+	"SVGAttributes",
+	"SVGElement",
+]);
+
+/**
+ * @param {import('jscodeshift').TSTypeReference['typeName']} typeName
+ * @returns {import('jscodeshift').Identifier | null}
+ */
+function getIdentifierFromTypeName(typeName) {
+	let identifier = null;
+
+	if (typeName.type === "Identifier") {
+		identifier = typeName;
+	}
+
+	if (
+		typeName.type === "TSQualifiedName" &&
+		typeName.right.type === "Identifier"
+	) {
+		identifier = typeName.right;
+	}
+
+	return identifier;
+}
+
+/**
+ * @type {import('jscodeshift').Transform}
+ */
+const deprecatedReactTextTransform = (file, api) => {
+	const j = api.jscodeshift;
+	const ast = parseSync(file);
+
+	const replacedIdentifiers = new Set();
+
+	const changedIdentifiers = ast
+		.find(j.TSTypeReference, (node) => {
+			const { typeName } = node;
+
+			const identifier = getIdentifierFromTypeName(typeName);
+
+			// this is a list of all @types/react imports used
+
+			return identifier !== null && typesToRemove.has(identifier.name);
+		})
+		.replaceWith((path) => {
+			const identifier = getIdentifierFromTypeName(path.value.typeName);
+
+			if (!identifier) {
+				return path.value;
+			}
+
+			replacedIdentifiers.add(identifier.name);
+
+			return j.tsTypeReference(
+				j.tsQualifiedName(j.identifier("React"), j.identifier(identifier.name))
+			);
+		});
+
+	// now remove those imports from "react"
+	if (replacedIdentifiers.size > 0) {
+		ast
+			.find(j.ImportDeclaration)
+			.filter((path) => path.node.source.value === "react")
+			.find(j.ImportSpecifier)
+			.filter((path) => replacedIdentifiers.has(path.node.imported.name))
+			.remove();
+
+		ast
+			.find(j.ImportDeclaration)
+			.filter((path) => path.node.source.value === "react")
+			.filter((path) =>
+				path.node.specifiers ? path.node.specifiers.length === 0 : false
+			)
+			.remove();
+	}
+
+	if (changedIdentifiers.length > 0) {
+		return ast.toSource();
+	}
+
+	return file.source;
+};
+
+module.exports = deprecatedReactTextTransform;


### PR DESCRIPTION
I used this codemon to remove all the type imports from React in my projects to just reference the global namespace of React. It's a cosmetic change but it keeps React imports to only be one used at runtime.

Optionally there could be a way to rework this to include type imports. So:

```ts
import { useState, MouseEvent } from 'react'
```

Into:

```ts
import { MouseEvent } from 'react'
import type { MouseEvent } from 'react'
```

or 

```ts
import { useState, type MouseEvent } from 'react'
```