### PR TITLE
chore: Dedupe deps on auto updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -8,6 +8,7 @@
 		"schedule": "before 6:00am on the first day of the month"
 	},
 	"packageRules": [],
+	"postUpdateOptions": ["yarnDedupeFewer"],
 	"prConcurrentLimit": 99,
 	"prHourlyLimit": 0,
 	"rangeStrategy": "update-lockfile",

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -31,5 +31,6 @@ jobs:
       - run: yarn test:lint
       - run: yarn test:types
       - run: yarn format:check
+      - run: yarn test:renovate
       # for manual inspection of included files
       - run: npm pack

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
 		"format:check": "prettier . --check",
 		"release": "yarn changeset publish",
 		"test:lint": "eslint bin/**/*.{cjs,js,mjs} transforms/**/*.{cjs,js,mjs}",
+		"test:renovate": "npx --package renovate -c renovate-config-validator",
 		"test:types": "tsc -p tsconfig.json --noEmit",
 		"test:unit": "jest"
 	},


### PR DESCRIPTION
Not sure if Renovate supports dedupe with Yarn v2+. `yarn-deduplicate` doesn't work with v2+ so Renovate would have to use `yarn dedupe` instead.