### PR TITLE
chore: Switch to "highest" strategy with `yarn dedupe`

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -8,7 +8,7 @@
 		"schedule": "before 6:00am on the first day of the month"
 	},
 	"packageRules": [],
-	"postUpdateOptions": ["yarnDedupeFewer"],
+	"postUpdateOptions": ["yarnDedupeHighest"],
 	"prConcurrentLimit": 99,
 	"prHourlyLimit": 0,
 	"rangeStrategy": "update-lockfile",


### PR DESCRIPTION
Seeing ["yarn dedupe fewer not available" in Renovate logs](https://app.renovatebot.com/dashboard#github/eps1lon/types-react-codemod/950470529) which makes sense since [Yarn v2+ only has "highest" as a strategy](https://yarnpkg.com/cli/dedupe).