### PR TITLE
Fix renovate validator failing in Node 14.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 		"format:check": "prettier . --check",
 		"release": "yarn changeset publish",
 		"test:lint": "eslint bin/**/*.{cjs,js,mjs} transforms/**/*.{cjs,js,mjs}",
-		"test:renovate": "npx --package renovate@35.22.2 -c renovate-config-validator",
+		"test:renovate": "npx --package renovate@31.21.2 -c renovate-config-validator",
 		"test:types": "tsc -p tsconfig.json --noEmit",
 		"test:unit": "jest"
 	},

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 		"format:check": "prettier . --check",
 		"release": "yarn changeset publish",
 		"test:lint": "eslint bin/**/*.{cjs,js,mjs} transforms/**/*.{cjs,js,mjs}",
-		"test:renovate": "npx --package renovate -c renovate-config-validator",
+		"test:renovate": "npx --package renovate@35.22.2 -c renovate-config-validator",
 		"test:types": "tsc -p tsconfig.json --noEmit",
 		"test:unit": "jest"
 	},
@@ -44,6 +44,6 @@
 		"access": "public"
 	},
 	"volta": {
-		"node": "18.14.2"
+		"node": "14.21.3"
 	}
 }


### PR DESCRIPTION
Pins `renovate-config-validator` to the version prior to https://github.com/renovatebot/renovate/pull/13416 which broke usage in Node.js 14.x (`??=` is not supported syntax in Node.js 14.x).