### PR TITLE
Fix install in CI

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -7013,11 +7013,11 @@ __metadata:
 
 "typescript@patch:typescript@^5.0.0#~builtin<compat/typescript>":
   version: 5.0.2
-  resolution: "typescript@patch:typescript@npm%3A5.0.2#~builtin<compat/typescript>::version=5.0.2&hash=1f5320"
+  resolution: "typescript@patch:typescript@npm%3A5.0.2#~builtin<compat/typescript>::version=5.0.2&hash=85af82"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: bdbf3d0aac0d6cf010fbe0536753dc19f278eb4aba88140dcd25487dfe1c56ca8b33abc0dcd42078790a939b08ebc4046f3e9bb961d77d3d2c3cfa9829da4d53
+  checksum: b63cb742fbb9aeb3085e002ad8f10d5fd963606aa4d6b3b65b4e76c396ff09739f03b5dbae08e1698c3bce9d5619d3f67aeb7ee470ed4016bd345b3cfe37b54a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes https://github.com/eps1lon/types-react-codemod/actions/runs/4524470554/jobs/7968326212

```
Post-resolution validation
  ➤ YN0000: │ @@ -7012,13 +7012,12 @@
  ➤ YN0000: │    linkType: hard
  ➤ YN0000: │  
  ➤ YN0000: │  "typescript@patch:typescript@^5.0.0#~builtin<compat/typescript>":
  ➤ YN0000: │    version: 5.0.2
  ➤ YN0028: │ -  resolution: "typescript@patch:typescript@npm%3A5.0.2#~builtin<compat/typescript>::version=5.0.2&hash=1f5320"
  ➤ YN0028: │ +  resolution: "typescript@patch:typescript@npm%3A5.0.2#~builtin<compat/typescript>::version=5.0.2&hash=85af82"
  ➤ YN0000: │    bin:
  ➤ YN0000: │      tsc: bin/tsc
  ➤ YN0000: │      tsserver: bin/tsserver
  ➤ YN0028: │ -  checksum: bdbf3d0aac0d6cf0[10](https://github.com/eps1lon/types-react-codemod/actions/runs/4524470554/jobs/7968326212#step:4:12)fbe0536753dc19f278eb4aba88140dcd25487dfe1c56ca8b33abc0dcd42078790a939b08ebc4046f3e9bb961d77d3d2c3cfa9829da4d53
  ➤ YN0000: │    languageName: node
  ➤ YN0000: │    linkType: hard
  ➤ YN0000: │  
  ➤ YN0000: │  "unbox-primitive@npm:^1.0.2":
  ➤ YN0000: │ 
  ➤ YN0028: │ The lockfile would have been modified by this install, which is explicitly forbidden.
```

Caused by merging TS and Yarn bump at the same time. They should've been stacked 