### PR TITLE
chore: update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
 		"test:unit": "jest"
 	},
 	"engines": {
-		"node": "14.x || 16.x || 17.x || 18.x || 19.x"
+		"node": "14.x || 16.x || 17.x || 18.x || 19.x || 20.x"
 	},
 	"dependencies": {
 		"@babel/core": "^7.17.8",


### PR DESCRIPTION
add current node LTS, 20.x, to list of "engines"
removes warning for 20.x users