### PR TITLE
test: Run release workflow with main Node.js version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,10 +16,10 @@ jobs:
           # This makes Actions fetch all Git history so that Changesets can generate changelogs with the correct commits
           fetch-depth: 0
 
-      - name: Setup Node.js 12.x
+      - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 12.x
+          node-version-file: package.json
 
       - name: Install Dependencies
         run: yarn


### PR DESCRIPTION
Fixes 
```
HEAD is now at 0730d90 feat(deps): update node.js to v20 (#304)
/opt/hostedtoolcache/node/12.22.12/x64/bin/node /home/runner/work/types-react-codemod/types-react-codemod/node_modules/@changesets/cli/bin.js version
🦋  error /home/runner/work/types-react-codemod/types-react-codemod/node_modules/prettier/index.cjs:474
🦋  error   const comments = node.comments ?? (node.comments = []);
🦋  error                                   ^
🦋  error 
🦋  error SyntaxError: Unexpected token '?'
🦋  error     at wrapSafe (internal/modules/cjs/loader.js:915:16)
🦋  error     at Module._compile (internal/modules/cjs/loader.js:963:27)
🦋  error     at Object.Module._extensions..js (internal/modules/cjs/loader.js:1027:10)
🦋  error     at Module.load (internal/modules/cjs/loader.js:863:32)
🦋  error     at Function.Module._load (internal/modules/cjs/loader.js:708:14)
🦋  error     at Module.require (internal/modules/cjs/loader.js:887:[19](https://github.com/eps1lon/types-react-codemod/actions/runs/7070629219/job/19247515057#step:5:20))
🦋  error     at require (internal/modules/cjs/helpers.js:74:18)
🦋  error     at getPrettierInstance (/home/runner/work/types-react-codemod/types-react-codemod/node_modules/@changesets/apply-release-

```

-- https://github.com/eps1lon/types-react-codemod/actions/runs/7070629219/job/19247515057