### PR TITLE
Drop Node.js 16 support

### DIFF
--- a/.changeset/kind-seahorses-visit.md
+++ b/.changeset/kind-seahorses-visit.md
@@ -4,4 +4,4 @@
 
 Update Node.js support matrix
 
-Drop support for unmaintained Node.js versions (14.x, 17.x, and 19.x) to reduce maintenance cost.
+Drop support for unmaintained Node.js versions (14.x, 16.x, 17.x, and 19.x) to reduce maintenance cost.

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         # #nodejs-suppport
-        node-version: [16.x, 18.x, 20.x]
+        node-version: [18.x, 20.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
 		"test:unit": "jest"
 	},
 	"engines": {
-		"node": "16.x || 18.x || 20.x"
+		"node": "18.x || 20.x"
 	},
 	"dependencies": {
 		"@babel/core": "^7.17.8",


### PR DESCRIPTION
Yarn v4 won't support 16 anyway.