### PR TITLE
docs:  Squash changesets

### DIFF
--- a/.changeset/fifty-cheetahs-dance.md
+++ b/.changeset/fifty-cheetahs-dance.md
@@ -4,5 +4,5 @@
 
 Add codemod for required initial value in `useRef`
 
-Added as `experimental-useRef-required-initial`.
+Added as `useRef-required-initial`.
 Can be used on 18.x types but only intended for once https://github.com/DefinitelyTyped/DefinitelyTyped/pull/64920 lands.

--- a/.changeset/kind-bugs-teach.md
+++ b/.changeset/kind-bugs-teach.md
@@ -9,6 +9,4 @@ Just removing their experimental prefix since we have increased confidence in th
 ```diff
 -experimental-refobject-defaults
 +refobject-defaults
--experimental-useRef-required-initial
-+useRef-required-initial
 ```


### PR DESCRIPTION
`experimental-useRef-required-initial` was never released so no need to mention it in the changelog