### PR TITLE
fix: Find and replace type usage in type parameters of call expressions

### DIFF
--- a/.changeset/short-zoos-type.md
+++ b/.changeset/short-zoos-type.md
@@ -1,0 +1,15 @@
+---
+"types-react-codemod": patch
+---
+
+Find and replace type usage in type parameters of call expressions
+
+Now we properly detect that e.g. `JSX` is used in `someFunctionWithTypeParameters<JSX>()`.
+
+Affected codemods:
+
+- `deprecated-react-child`
+- `deprecated-react-fragment`
+- `deprecated-react-node-array`
+- `deprecated-react-text`
+- `scoped-jsx`

--- a/transforms/__tests__/deprecated-react-child.js
+++ b/transforms/__tests__/deprecated-react-child.js
@@ -78,4 +78,16 @@ describe("transform deprecated-react-child", () => {
 		}"
 	`);
 	});
+
+	test("as type parameter", () => {
+		expect(
+			applyTransform(`
+			import * as React from 'react';
+			createAction<React.ReactChild>()
+		`),
+		).toMatchInlineSnapshot(`
+		"import * as React from 'react';
+		createAction<React.ReactElement | number | string>()"
+	`);
+	});
 });

--- a/transforms/__tests__/deprecated-react-fragment.js
+++ b/transforms/__tests__/deprecated-react-fragment.js
@@ -126,4 +126,16 @@ describe("transform deprecated-react-node-array", () => {
 		}"
 	`);
 	});
+
+	test("as type parameter", () => {
+		expect(
+			applyTransform(`
+      import * as React from 'react';
+      createComponent<React.ReactFragment>();
+    `),
+		).toMatchInlineSnapshot(`
+		"import * as React from 'react';
+		createComponent<Iterable<React.ReactNode>>();"
+	`);
+	});
 });

--- a/transforms/__tests__/deprecated-react-node-array.js
+++ b/transforms/__tests__/deprecated-react-node-array.js
@@ -126,4 +126,16 @@ describe("transform deprecated-react-node-array", () => {
 		}"
 	`);
 	});
+
+	test("in type parameters", () => {
+		expect(
+			applyTransform(`
+      import * as React from 'react';
+      createComponent<ReactNodeArray>();
+    `),
+		).toMatchInlineSnapshot(`
+		"import * as React from 'react';
+		createComponent<ReadonlyArray<ReactNode>>();"
+	`);
+	});
 });

--- a/transforms/__tests__/deprecated-react-text.js
+++ b/transforms/__tests__/deprecated-react-text.js
@@ -78,4 +78,16 @@ describe("transform deprecated-react-text", () => {
 		}"
 	`);
 	});
+
+	test("in type parameters", () => {
+		expect(
+			applyTransform(`
+      import * as React from 'react';
+      createComponent<React.ReactText>();
+    `),
+		).toMatchInlineSnapshot(`
+		"import * as React from 'react';
+		createComponent<number | string>();"
+	`);
+	});
 });

--- a/transforms/__tests__/scoped-jsx.js
+++ b/transforms/__tests__/scoped-jsx.js
@@ -5,7 +5,7 @@ const scopedJSXTransform = require("../scoped-jsx");
 
 function applyTransform(source, options = {}) {
 	return JscodeshiftTestUtils.applyTransform(scopedJSXTransform, options, {
-		path: "test.d.ts",
+		path: "test.tsx",
 		source: dedent(source),
 	});
 }
@@ -173,6 +173,22 @@ describe("transform scoped-jsx", () => {
 		import type { JSX } from "react";
 
 		declare const attributes: JSX.LibraryManagedAttributes<A, B>;"
+	`);
+	});
+
+	test("detects usage in type parameters", () => {
+		expect(
+			applyTransform(`
+			import React, { useMemo } from 'react'
+
+			[].reduce<JSX.Element[]>((acc, component, i) => {});
+			[].reduce((acc, component, i) => {})
+			`),
+		).toMatchInlineSnapshot(`
+		"import React, { useMemo, type JSX } from 'react';
+
+		[].reduce<JSX.Element[]>((acc, component, i) => {});
+		[].reduce((acc, component, i) => {})"
 	`);
 	});
 });

--- a/transforms/utils/jscodeshift-bugfixes.js
+++ b/transforms/utils/jscodeshift-bugfixes.js
@@ -1,0 +1,24 @@
+/**
+ * This function returns all TSTypeReference collections in the AST.
+ *
+ * ast.find(TSTypeReference) does not find type references in type parameters of call expression.
+ * @param {import('jscodeshift').API['jscodeshift']} j
+ * @param {import('jscodeshift').Collection} ast
+ * @param {(path: import('jscodeshift').TSTypeReference) => boolean} filter
+ */
+function findTSTypeReferenceCollections(j, ast, filter) {
+	return [
+		ast.find(j.TSTypeReference, filter),
+		ast
+			.find(j.CallExpression, (node) => {
+				// @ts-expect-error ast-types does not know about typeParameters which is probably why it doesn't visit them.
+				return node.typeParameters !== undefined;
+			})
+			.map((path) => {
+				return path.get("typeParameters");
+			})
+			.find(j.TSTypeReference, filter),
+	];
+}
+
+module.exports = { findTSTypeReferenceCollections };


### PR DESCRIPTION
Annoying bug in ast-types/recast?