### PR TITLE
fix: missing dependencies for pnpx

### DIFF
--- a/.changeset/fifty-schools-shout.md
+++ b/.changeset/fifty-schools-shout.md
@@ -1,0 +1,7 @@
+---
+"types-react-codemod": patch
+---
+
+Declare dependency on `@babel/types`
+
+Fixes `types-react-codemod tried to access @babel/types, but it isn't declared in its dependencies; this makes the require call ambiguous and unsound`

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
 		"@babel/core": "^7.17.8",
 		"@babel/parser": "^7.17.8",
 		"@babel/preset-env": "^7.16.11",
+		"@babel/types": "^7.17.8",
 		"inquirer": "^9.0.0",
 		"jscodeshift": "^0.16.0",
 		"yargs": "^17.4.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1367,7 +1367,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/types@npm:^7.0.0, @babel/types@npm:^7.20.7, @babel/types@npm:^7.25.7, @babel/types@npm:^7.25.8, @babel/types@npm:^7.3.3, @babel/types@npm:^7.4.4":
+"@babel/types@npm:^7.0.0, @babel/types@npm:^7.17.8, @babel/types@npm:^7.20.7, @babel/types@npm:^7.25.7, @babel/types@npm:^7.25.8, @babel/types@npm:^7.3.3, @babel/types@npm:^7.4.4":
   version: 7.25.8
   resolution: "@babel/types@npm:7.25.8"
   dependencies:
@@ -6189,6 +6189,7 @@ __metadata:
     "@babel/core": ^7.17.8
     "@babel/parser": ^7.17.8
     "@babel/preset-env": ^7.16.11
+    "@babel/types": ^7.17.8
     "@changesets/changelog-github": ^0.5.0
     "@changesets/cli": ^2.22.0
     "@jest/globals": ^29.0.0


### PR DESCRIPTION
### What

Seeing error with yarn running the codemod

```
Require stack:
- /private/var/folders/gy/kq4zjn8s0ljf9sfjyyh_nj640000gn/T/xfs-7876c1ec/dlx-47763/.yarn/cache/types-react-codemod-npm-3.4.0-ab138b8b9f-7732b43362.zip/node_modules/types-react-c
odemod/transforms/refobject-defaults.js
- /private/var/folders/gy/kq4zjn8s0ljf9sfjyyh_nj640000gn/T/xfs-7876c1ec/dlx-47763/.yarn/cache/types-react-codemod-npm-3.4.0-ab138b8b9f-7732b43362.zip/node_modules/types-react-c
odemod/transforms/preset-19./private/var/folders/gy/kq4zjn8s0ljf9sfjyyh_nj640000gn/T/xfs-7876c1ec/dlx-47763/.pnp.cjs:9375
      Error.captureStackTrace(firstError);
            ^

Error: types-react-codemod tried to access @babel/types, but it isn't declared in its dependencies; this makes the require call ambiguous and unsound.

Required package: @babel/types
Required by: types-react-codemod@npm:3.4.0 (via /private/var/folders/gy/kq4zjn8s0ljf9sfjyyh_nj640000gn/T/xfs-7876c1ec/dlx-47763/.yarn/cache/types-react-codemod-npm-3.4.0-ab138b
8b9f-7732b43362.zip/node_modules/types-react-codemod/transforms/)

```

`@babel/types` is a required dependencies for babel, adding it here to ensure it's get installed