### PR TITLE
Stop using `@babel/types`

### DIFF
--- a/.changeset/light-news-end.md
+++ b/.changeset/light-news-end.md
@@ -1,0 +1,7 @@
+---
+"types-react-codemod": patch
+---
+
+Stop using `@babel/types`
+
+Fixes `types-react-codemod tried to access @babel/types, but it isn't declared in its dependencies; this makes the require call ambiguous and unsound`

--- a/transforms/refobject-defaults.js
+++ b/transforms/refobject-defaults.js
@@ -1,5 +1,4 @@
 const parseSync = require("./utils/parseSync");
-const t = require("@babel/types");
 const traverse = require("@babel/traverse").default;
 
 /**
@@ -12,7 +11,8 @@ const traverse = require("@babel/traverse").default;
  * 82 ok
  * Fixes all remaining issues outside of n_m
  */
-const refObjectDefaultsTransform = (file) => {
+const refObjectDefaultsTransform = (file, api) => {
+	const j = api.jscodeshift;
 	const ast = parseSync(file);
 
 	let changedSome = false;
@@ -21,7 +21,7 @@ const refObjectDefaultsTransform = (file) => {
 	// TODO: How to test?
 	const traverseRoot = ast.paths()[0].value;
 	/**
-	 * @type {import('@babel/types').TSTypeReference[]}
+	 * @type {import('jscodeshift').TSTypeReference[]}
 	 */
 	const refObjectTypeReferences = [];
 	traverse(traverseRoot, {
@@ -58,18 +58,18 @@ const refObjectDefaultsTransform = (file) => {
 
 					nullableType = unionIsApparentlyNullable
 						? typeNode
-						: t.tsUnionType([...typeNode.types, t.tsNullKeyword()]);
+						: j.tsUnionType([...typeNode.types, j.tsNullKeyword()]);
 				}
 			} else {
 				if (typeNode.type !== "TSAnyKeyword") {
-					nullableType = t.tsUnionType([typeNode, t.tsNullKeyword()]);
+					nullableType = j.tsUnionType([typeNode, j.tsNullKeyword()]);
 				}
 			}
 
 			if (nullableType !== undefined && nullableType !== typeNode) {
 				// Ideally we'd clone the `typeReference` path and add `typeParameters`.
 				// But I don't know if there's an API or better pattern for it.
-				typeReference.typeParameters = t.tsTypeParameterInstantiation([
+				typeReference.typeParameters = j.tsTypeParameterInstantiation([
 					nullableType,
 				]);
 				changedSome = true;

--- a/transforms/useRef-required-initial.js
+++ b/transforms/useRef-required-initial.js
@@ -1,5 +1,4 @@
 const parseSync = require("./utils/parseSync");
-const t = require("@babel/types");
 const traverse = require("@babel/traverse").default;
 
 /**
@@ -8,7 +7,8 @@ const traverse = require("@babel/traverse").default;
  * Summary for Klarna's klapp@?
  * TODO
  */
-const useRefRequiredInitialTransform = (file) => {
+const useRefRequiredInitialTransform = (file, api) => {
+	const j = api.jscodeshift;
 	const ast = parseSync(file);
 
 	let changedSome = false;
@@ -27,7 +27,7 @@ const useRefRequiredInitialTransform = (file) => {
 
 			if (isUseRefCall && callExpression.arguments.length === 0) {
 				changedSome = true;
-				callExpression.arguments = [t.identifier("undefined")];
+				callExpression.arguments = [j.identifier("undefined")];
 			}
 		},
 	});


### PR DESCRIPTION
We can use `jscodeshift` API like we do in the other
transforms.