### PR TITLE
fix(replaceType): handle array syntax

### DIFF
--- a/.changeset/wise-icons-wash.md
+++ b/.changeset/wise-icons-wash.md
@@ -1,0 +1,5 @@
+---
+"types-react-codemod": patch
+---
+
+Handle array syntax in replaceReactType

--- a/.changeset/wise-icons-wash.md
+++ b/.changeset/wise-icons-wash.md
@@ -2,4 +2,6 @@
 "types-react-codemod": patch
 ---
 
-Handle array syntax in replaceReactType
+Fix a bug when replacing types in shorthand array type notations.
+
+For example, replacing `ReactText` in `ReactText[]` should now result in `(number | string)[]` instead of `number | string[]`.

--- a/transforms/__tests__/deprecated-react-child.js
+++ b/transforms/__tests__/deprecated-react-child.js
@@ -121,3 +121,19 @@ test("as type parameter", () => {
 		createAction<React.ReactElement | number | string>()"
 	`);
 });
+
+test("array syntax", () => {
+	expect(
+		applyTransform(`
+      import { ReactChild } from 'react';
+		interface Props {
+				children?: ReactChild[];
+			}
+    `),
+	).toMatchInlineSnapshot(`
+		"import { ReactElement } from 'react';
+		interface Props {
+				children?: (ReactElement | number | string)[];
+			}"
+	`);
+});

--- a/transforms/__tests__/deprecated-react-child.js
+++ b/transforms/__tests__/deprecated-react-child.js
@@ -122,18 +122,34 @@ test("as type parameter", () => {
 	`);
 });
 
-test("array syntax", () => {
+test("array type syntax", () => {
 	expect(
 		applyTransform(`
-      import { ReactChild } from 'react';
-		interface Props {
+			import { ReactChild } from 'react';
+			interface Props {
 				children?: ReactChild[];
 			}
-    `),
+		`),
 	).toMatchInlineSnapshot(`
 		"import { ReactElement } from 'react';
 		interface Props {
-				children?: (ReactElement | number | string)[];
-			}"
+			children?: (ReactElement | number | string)[];
+		}"
+	`);
+});
+
+test("Array generic", () => {
+	expect(
+		applyTransform(`
+			import { ReactChild } from 'react';
+			interface Props {
+				children?: Array<ReactChild>;
+			}
+		`),
+	).toMatchInlineSnapshot(`
+		"import { ReactElement } from 'react';
+		interface Props {
+			children?: Array<ReactElement | number | string>;
+		}"
 	`);
 });

--- a/transforms/utils/replaceType.js
+++ b/transforms/utils/replaceType.js
@@ -113,8 +113,16 @@ function replaceReactType(
 		},
 	);
 	for (const typeReferences of sourceIdentifierTypeReferences) {
-		const changedIdentifiers = typeReferences.replaceWith((path) => {
-			return buildTargetTypeReference(path.value);
+		const changedIdentifiers = typeReferences.forEach((path) => {
+			const targetNode = buildTargetTypeReference(path.value);
+			if (
+				targetNode.type === "TSUnionType" &&
+				path.parentPath.value.type === "TSArrayType"
+			) {
+				path.replace(j.tsParenthesizedType(targetNode));
+			} else {
+				path.replace(targetNode);
+			}
 		});
 		if (changedIdentifiers.length > 0) {
 			hasChanges = true;


### PR DESCRIPTION
This PR fixes an issue that we encountered running the React 19 codemods that would result in incorrect types like:

```diff
- children?: ReactChild[];
+ children?: ReactElement | number | string[];
```

I'm not sure if it's actually a bug in the recast printer but I think the solution here makes sense. We check if the parent is a `TSArrayType` and add parenthesis add a `TSParenthesizedType` wrapper if appropriate. 