### PR TITLE
fix(replaceType): avoid modifying import not from 'react'

### DIFF
--- a/.changeset/sharp-dancers-breathe.md
+++ b/.changeset/sharp-dancers-breathe.md
@@ -1,0 +1,5 @@
+---
+"types-react-codemod": patch
+---
+
+Avoid modifying import not from `'react'` when replacing types.

--- a/transforms/__tests__/deprecated-react-node-array.js
+++ b/transforms/__tests__/deprecated-react-node-array.js
@@ -129,11 +129,29 @@ test("namespace import", () => {
 test("in type parameters", () => {
 	expect(
 		applyTransform(`
-      import * as React from 'react';
+      import { ReactNodeArray } from 'react';
       createComponent<ReactNodeArray>();
     `),
 	).toMatchInlineSnapshot(`
-		"import * as React from 'react';
+		"import { ReactNode } from 'react';
 		createComponent<ReadonlyArray<ReactNode>>();"
+	`);
+});
+
+test("import from 'prop-types'", () => {
+	expect(
+		applyTransform(`
+      import { ReactNodeArray} from 'prop-types';
+      interface Props {
+  			href: string;
+  			children: ReactNodeArray;
+			};
+    `),
+	).toMatchInlineSnapshot(`
+		"import { ReactNodeArray} from 'prop-types';
+		   interface Props {
+				href: string;
+				children: ReactNodeArray;
+		};"
 	`);
 });

--- a/transforms/utils/replaceType.js
+++ b/transforms/utils/replaceType.js
@@ -104,7 +104,8 @@ function replaceReactType(
 			const { typeName } = node;
 
 			return (
-				(typeName.type === "Identifier" &&
+				(sourceIdentifierImports.length &&
+					typeName.type === "Identifier" &&
 					typeName.name === sourceIdentifier) ||
 				(typeName.type === "TSQualifiedName" &&
 					typeName.right.type === "Identifier" &&

--- a/transforms/utils/replaceType.js
+++ b/transforms/utils/replaceType.js
@@ -104,7 +104,7 @@ function replaceReactType(
 			const { typeName } = node;
 
 			return (
-				(sourceIdentifierImports.length &&
+				(sourceIdentifierImports.length > 0 &&
 					typeName.type === "Identifier" &&
 					typeName.name === sourceIdentifier) ||
 				(typeName.type === "TSQualifiedName" &&


### PR DESCRIPTION
This fixes an edge case we ran into where `ReactNodeArray` was being imported from `'prop-types'` but still being modified. The fix is to consider whether a named import exists when looking for references to that import. I'm aware that `prop-types` are going away in React 19 but I was modifying a React 18 codebase for forwards compatibility.

This fix also caught a typo with the `"in type parameters"` test. 