### PR TITLE
fix(scoped-jsx): Don't add `JSX` import if `JSX` is already imported

### DIFF
--- a/.changeset/olive-suns-crash.md
+++ b/.changeset/olive-suns-crash.md
@@ -1,0 +1,5 @@
+---
+"types-react-codemod": patch
+---
+
+fix(scoped-jsx): Don't add `JSX` import if `JSX` is already imported

--- a/transforms/__tests__/scoped-jsx.js
+++ b/transforms/__tests__/scoped-jsx.js
@@ -191,4 +191,16 @@ describe("transform scoped-jsx", () => {
 		[].reduce((acc, component, i) => {})"
 	`);
 	});
+
+	test("existing JSX import from jsx-runtime", () => {
+		expect(
+			applyTransform(`
+				import { JSX } from 'react/jsx-runtime';
+				declare const element: JSX.Element;
+			`),
+		).toMatchInlineSnapshot(`
+		"import { JSX } from 'react/jsx-runtime';
+		declare const element: JSX.Element;"
+	`);
+	});
 });

--- a/transforms/scoped-jsx.js
+++ b/transforms/scoped-jsx.js
@@ -34,7 +34,7 @@ const scopedJsxTransform = (file, api) => {
 		},
 	});
 
-	if (hasGlobalNamespaceReferences && !jsxImportedFromJsxRuntime(j, ast)) {
+	if (hasGlobalNamespaceReferences && !isJsxAlreadyImported(j, ast)) {
 		const reactImport = findReactImportForNewImports(j, ast);
 		const jsxImportSpecifier = reactImport.find(j.ImportSpecifier, {
 			imported: { name: "JSX" },
@@ -77,21 +77,11 @@ const scopedJsxTransform = (file, api) => {
  * @param {import('jscodeshift').API['jscodeshift']} j
  * @param {import('jscodeshift').Collection} ast
  */
-function jsxImportedFromJsxRuntime(j, ast) {
+function isJsxAlreadyImported(j, ast) {
 	return (
-		ast
-			.find(j.ImportSpecifier, {
-				imported: { name: "JSX" },
-				local: { name: "JSX" },
-			})
-			.filter((path) => {
-				return (
-					path.parent &&
-					path.parent.node.type === "ImportDeclaration" &&
-					(path.parent.node.source.value === "react/jsx-runtime" ||
-						path.parent.node.source.value === "react/jsx-dev-runtime")
-				);
-			}).length > 0
+		ast.find(j.ImportSpecifier, {
+			local: { name: "JSX" },
+		}).length > 0
 	);
 }
 


### PR DESCRIPTION
This fixes a limitation we ran into with the `scoped-jsx` codemod. There were a couple places that were importing `{ JSX } from 'react/jsx-runtime'` but the new `react` import was still being added. I assume that that code should just be importing from `'react'` to begin with but just wanted to push the PR in case it ends up being a common issue. 
